### PR TITLE
utils: replace isPlainObject with a robuster implementation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,15 +162,29 @@ export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
 }
 
 // Check if object doens't have custom constructor (like Uint8Array/Array)
-const isPlainObject = (obj: any) =>
-  Object.prototype.toString.call(obj) === '[object Object]' && obj.constructor === Object;
+//
+// Copied from https://www.npmjs.com/package/is-plain-obj v4.1.0, MIT
+function isPlainObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return (
+    (prototype === null ||
+      prototype === Object.prototype ||
+      Object.getPrototypeOf(prototype) === null) &&
+    !(Symbol.toStringTag in value) &&
+    !(Symbol.iterator in value)
+  );
+}
 
 type EmptyObj = {};
 export function checkOpts<T1 extends EmptyObj, T2 extends EmptyObj>(
   defaults: T1,
   opts?: T2
 ): T1 & T2 {
-  if (opts !== undefined && (typeof opts !== 'object' || !isPlainObject(opts)))
+  if (opts !== undefined && !isPlainObject(opts))
     throw new Error('options must be object or undefined');
   const merged = Object.assign(defaults, opts);
   return merged as T1 & T2;


### PR DESCRIPTION
Copy the code from the NPM package `is-plain-obj` to replace our current `isPlainObject` implementation. Closes https://github.com/paulmillr/noble-ciphers/issues/21.

I choose to copy code instead of adding it as a dependency because of the following reasons:

1. `is-plain-obj` is an ESM-only package, while noble is an ESM-CJS dual package. 
2. `@noble/ciphers` is designed as zero-dependency. 