### PR TITLE
fix: cleanup in gcm tag mismatch

### DIFF
--- a/src/aes.ts
+++ b/src/aes.ts
@@ -972,7 +972,10 @@ export const gcm: TRet<
         toClean.push(tag);
         // NIST SP 800-38D §7.2 permits equivalent step orderings; verify the
         // tag before CTR so unauthenticated plaintext is never materialized.
-        if (!equalBytes(tag, passedTag)) throw new Error('aes/gcm: invalid ghash tag');
+        if (!equalBytes(tag, passedTag)) {
+          clean(...toClean);
+          throw new Error('aes/gcm: invalid ghash tag');
+        }
         const out = ctr32(xk, false, counter, data);
         clean(...toClean);
         return out as TRet<Uint8Array>;


### PR DESCRIPTION
Wiping `[xk, authKey, tagMask, counter]` on failure was never done, only on success

See also SIV (which has a better reason to do that though because of plaintext)
https://github.com/paulmillr/noble-ciphers/blob/4361ffc3e6793d2165d56ffa948a00e7465af74b/src/aes.ts#L1137-L1140

No tests seem to fail + no one _should_ be attempting to call decrypt with the same params/instance on failures again I think