### PR TITLE
fix: cleanup on salsa and chacha tag mismatch

### DIFF
--- a/src/chacha.ts
+++ b/src/chacha.ts
@@ -469,7 +469,10 @@ export const _poly1305_aead =
         const tag = computeTag(xorStream, key, nonce, data, AAD);
         // RFC 8439 §2.8 / §4: authenticate ciphertext before decrypting it, and compare tags with
         // the constant-time equalBytes() helper rather than decrypting speculative plaintext first.
-        if (!equalBytes(passedTag, tag)) throw new Error('invalid tag');
+        if (!equalBytes(passedTag, tag)) {        
+          clean(tag);
+          throw new Error('invalid tag');
+        }
         output.set(ciphertext.subarray(0, -tagLength));
         // Actual decryption
         xorStream(

--- a/src/salsa.ts
+++ b/src/salsa.ts
@@ -327,7 +327,7 @@ export const xsalsa20poly1305: TRet<ARXCipher> = /* @__PURE__ */ wrapCipher(
         const authKey = xsalsa20(key, nonce, tmp, tmp);
         const tag = poly1305(ciphPlaintext, authKey);
         if (!equalBytes(passedTag, tag)) {
-          clean(tmp, passedTag, tag);
+          clean(output);
           throw new Error('invalid tag');
         }
         // output = stream ^ output[16..]

--- a/src/salsa.ts
+++ b/src/salsa.ts
@@ -326,7 +326,10 @@ export const xsalsa20poly1305: TRet<ARXCipher> = /* @__PURE__ */ wrapCipher(
         clean(tmp);
         const authKey = xsalsa20(key, nonce, tmp, tmp);
         const tag = poly1305(ciphPlaintext, authKey);
-        if (!equalBytes(passedTag, tag)) throw new Error('invalid tag');
+        if (!equalBytes(passedTag, tag)) {
+          clean(tmp, passedTag, tag);
+          throw new Error('invalid tag');
+        }
         // output = stream ^ output[16..]
         xsalsa20(key, nonce, output.subarray(16), output.subarray(16));
         clean(tmp, passedTag, tag);


### PR DESCRIPTION
Same as #67 but for salsa and chacha
Salsa `tmp, passedTag, tag` are all subarrays of `output` (which is a function param)