### PR TITLE
fix: numberToBytesBE overflow returning more than len bytes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -561,7 +561,10 @@ export function numberToBytesBE(n: number | bigint, len: number): TRet<Uint8Arra
   if (typeof n === 'number') anumber(n);
   else if (typeof n !== 'bigint') throw new TypeError(`number or bigint expected, got ${typeof n}`);
   anumber(len);
-  return hexToBytes(n.toString(16).padStart(len * 2, '0'));
+  const hex = n.toString(16).padStart(len * 2, '0');
+  if (hex.length > len * 2)
+    throw new RangeError('number ' + n + ' does not fit in ' + len + ' bytes');
+  return hexToBytes(hex);
 }
 
 // Global symbols, but ts doesn't see them:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -563,7 +563,7 @@ export function numberToBytesBE(n: number | bigint, len: number): TRet<Uint8Arra
   anumber(len);
   const hex = n.toString(16).padStart(len * 2, '0');
   if (hex.length > len * 2)
-    throw new RangeError('number ' + n + ' does not fit in ' + len + ' bytes');
+    throw new RangeError('number does not fit in ' + len + ' bytes');
   return hexToBytes(hex);
 }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -131,9 +131,14 @@ export function test({ describe, should } = BT) {
     });
     should('numberToBytesBE', () => {
       eql(u.numberToBytesBE(1, 2), Uint8Array.of(0, 1));
+      eql(u.numberToBytesBE(0xffn, 1), Uint8Array.of(0xff));
       throws(() => u.numberToBytesBE('1' as any, 2), TypeError);
       throws(() => u.numberToBytesBE(true as any, 2), TypeError);
       throws(() => u.numberToBytesBE(1, '2' as any), TypeError);
+      // value exceeds requested byte length
+      throws(() => u.numberToBytesBE(0xffffn, 1), RangeError);
+      throws(() => u.numberToBytesBE(0xffffffffn, 2), RangeError);
+      throws(() => u.numberToBytesBE(256, 1), RangeError);
     });
     should('utf8ToBytes', () => {
       eql(u.utf8ToBytes('abc'), new Uint8Array([97, 98, 99]));


### PR DESCRIPTION
When a bigint exceeded the capacity of the requested byte length, the hex string produced by toString(16) was longer than len*2. padStart is a no-op in that case, and if the hex happened to be even-length it passed hexToBytes without error, silently returning more bytes than the caller asked for. Add an explicit length check after padding and throw a RangeError when the value does not fit.